### PR TITLE
Prevent mock example code from evaluating

### DIFF
--- a/code_interfaces.livemd
+++ b/code_interfaces.livemd
@@ -38,11 +38,15 @@ You will add 3 code interfaces for:
 For each resource you want to add a code interface to, inside that resource definition on the domain, you will place "definitions".
 For example:
 
+<!-- livebook:{"force_markdown":true} -->
+
 ```elixir
 resource MyApp.Tweet do
   define :create_tweet, args: [:content]
 end
 ```
+
+<!-- livebook:{"break_markdown":true} -->
 
 Then add the 3 interfaces by defining the following inside the `Ticket` resource's block:
 


### PR DESCRIPTION
An example code block that is not meant to be evaluated was being treated as a code cell, rather than a code block within a markdown cell.