### PR TITLE
Update title index to match its new position

### DIFF
--- a/querying.livemd
+++ b/querying.livemd
@@ -1,4 +1,4 @@
-# Ash: 5 - Querying
+# Ash: 3 - Querying
 
 ```elixir
 Application.put_env(:ash, :validate_domain_resource_inclusion?, false)


### PR DESCRIPTION
In https://github.com/ash-project/ash_tutorial/commit/78e58f1e03cafa6cfe5bf096aa2a5af455e5f8e0, it looks like the query page got moved from index 5, to 3. But the title was not updated. 

This minor PR fixes that. 

Screenshots of the issue: 

![Screenshot 2024-04-18 at 14 49 18](https://github.com/ash-project/ash_tutorial/assets/7713/c641e957-0c83-4552-9619-427ddc1cd1ed)
![Screenshot 2024-04-18 at 14 49 22](https://github.com/ash-project/ash_tutorial/assets/7713/963a4328-848d-4e42-8276-3ee32b7e00ec)
