### PR TITLE
Correct domain resource parameter and add default_accept

### DIFF
--- a/managing_relationships.livemd
+++ b/managing_relationships.livemd
@@ -114,9 +114,13 @@ end
 
 defmodule Tutorial.Support.Representative do
   use Ash.Resource,
+    domain: Tutorial.Support,
     data_layer: Ash.DataLayer.Ets
 
-  actions(do: defaults([:create, :read, :update, :destroy]))
+  actions do
+    defaults([:create, :read, :update, :destroy])
+    default_accept([:name])
+  end
 
   attributes do
     uuid_primary_key(:id)


### PR DESCRIPTION
Before these changes, livebook default code for `Create a Representative:` first fails with `Could not determine domain for changeset.`, after adding the domain, it fails with `No such input `name` for action Tutorial.Support.Representative.create`