### PR TITLE
Propose for create_representative instead of create_ticket

### DIFF
--- a/code_interfaces.livemd
+++ b/code_interfaces.livemd
@@ -51,7 +51,7 @@ Then add the 3 interfaces by defining the following inside the `Ticket` resource
 
 And the following inside the `Representative` resource's block.
 
-* `define :create_ticket, args: [:name], action: :create`
+* `define :create_representative, args: [:name], action: :create`
 
 <details class="rounded-lg my-4" style="background-color: #96ef86; color: #040604;">
   <summary class="cursor-pointer font-bold p-4"></i>Show Solution</summary>


### PR DESCRIPTION
Solution and tutorial flow suggest that `create_representative` method is needed, while `create_ticket` is proposed in the tutorial. 