### PR TITLE
Replace deprecated calls for create and read_one

### DIFF
--- a/attributes.livemd
+++ b/attributes.livemd
@@ -283,7 +283,7 @@ Finally call `Ash.read_one!()` on the query.
   Tutorial.Support.Ticket
   |> Ash.Query.sort(created_at: :desc)
   |> Ash.Query.limit(1)
-  |> Tutorial.Support.read_one!()
+  |> Ash.read_one!()
   ```
 
   </div>

--- a/calculations.livemd
+++ b/calculations.livemd
@@ -89,7 +89,7 @@ Create a User and load in the `full_name`
 ```elixir
 Tutorial.Accounts.User
 |> Ash.Changeset.for_create(:create, %{first_name: "Joe", last_name: "Armstrong"})
-|> Tutorial.Accounts.create!()
+|> Ash.create!()
 |> Ash.load!([:full_name])
 ```
 


### PR DESCRIPTION
There are two deprecated calls in the tutorial which beeing replace in this pr.