### PR TITLE
Make minor correction to 'Attributes' tutorial page

### DIFF
--- a/attributes.livemd
+++ b/attributes.livemd
@@ -267,7 +267,7 @@ Now try creating a ticket with the status set to `:pending`. This should give an
 
 Since you added a creation date, you can now query on the latest created ticket.
 
-First, sort using the `Ash.Query.sort/1` function by `Ash.Query.sort(created_at: :desc)`
+First, sort using the `Ash.Query.sort/2` function by `Ash.Query.sort(created_at: :desc)`
 
 Then limit the amount of records with the `Ash.Query.limit/2` function by doing `Ash.Query.limit(1)`
 


### PR DESCRIPTION
When working through the tutorial this confused me for a couple of seconds. Technically there's no Ash.Query.sort/1, because the first argument is the query, usually piped into the function.