### PR TITLE
Update page index in title 

### DIFF
--- a/aggregates.livemd
+++ b/aggregates.livemd
@@ -1,4 +1,4 @@
-# Ash: 11 - Aggregates
+# Ash: 8 - Aggregates
 
 ```elixir
 Application.put_env(:ash, :validate_domain_resource_inclusion?, false)

--- a/attributes.livemd
+++ b/attributes.livemd
@@ -1,4 +1,4 @@
-# Ash: 6 - Attributes
+# Ash: 4 - Attributes
 
 ```elixir
 Application.put_env(:ash, :validate_domain_resource_inclusion?, false)

--- a/calculations.livemd
+++ b/calculations.livemd
@@ -1,4 +1,4 @@
-# Ash: 12 - Calculations
+# Ash: 9 - Calculations
 
 ```elixir
 Application.put_env(:ash, :validate_domain_resource_inclusion?, false)

--- a/code_interfaces.livemd
+++ b/code_interfaces.livemd
@@ -1,4 +1,4 @@
-# Ash: 10 - Code Interfaces
+# Ash: 7 - Code Interfaces
 
 ```elixir
 Application.put_env(:ash, :validate_domain_resource_inclusion?, false)

--- a/customizing_actions.livemd
+++ b/customizing_actions.livemd
@@ -1,4 +1,4 @@
-# Ash: 7 - Customizing Actions
+# Ash: 5 - Customizing Actions
 
 ```elixir
 Application.put_env(:ash, :validate_domain_resource_inclusion?, false)
@@ -134,7 +134,7 @@ defmodule Tutorial.Support.Ticket do
 
   actions do
     defaults [:read]
-    
+
     # <-- Add the :open and :close action
   end
 

--- a/relationships.livemd
+++ b/relationships.livemd
@@ -1,4 +1,4 @@
-# Ash: 8 - Relationships
+# Ash: 6 - Relationships
 
 ```elixir
 Application.put_env(:ash, :validate_domain_resource_inclusion?, false)


### PR DESCRIPTION
The `overview.livemd` livebook lists 9 chapters as of the latest commits, but when navigating, the jump from `querying.livemd` to `attributes.livemd` shows Ash 6: in title instead of Ash: 4 resulting in out of order indexes for all subsequent livebook titles.
![image](https://github.com/user-attachments/assets/9018d205-bd1e-4734-92c9-76110878a6b4)
![image](https://github.com/user-attachments/assets/c82945eb-f757-4854-986b-56f47e6295ff)

This initially confused me as I thought I was missing some lessons.

This PR fixes that by rewriting the indexes in order listed in the overview livebook.

